### PR TITLE
getFields and getMethods not including current class when including superClasses

### DIFF
--- a/api/src/main/java/fade/mirror/internal/impl/BasicMirrorClass.java
+++ b/api/src/main/java/fade/mirror/internal/impl/BasicMirrorClass.java
@@ -163,7 +163,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public @NotNull Stream<MField<?>> getFields(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(MClass::getFields);
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).flatMap(MClass::getFields);
         return this.getFields();
     }
 
@@ -175,7 +175,7 @@ public final class BasicMirrorClass<T>
     @Override
     @SuppressWarnings("unchecked")
     public @NotNull <F> Stream<MField<F>> getFields(@NotNull Predicate<MField<F>> filter, @NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(clazz -> clazz.getFields(filter));
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).flatMap(clazz -> clazz.getFields(filter));
         return this.getFields().map(field -> (MField<F>) field).filter(filter);
     }
 
@@ -197,7 +197,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public boolean hasFields(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().anyMatch(MClass::hasFields);
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).anyMatch(MClass::hasFields);
         return this.getFieldCount() > 0;
     }
 
@@ -208,7 +208,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public int getFieldCount(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().mapToInt(MClass::getFieldCount).sum();
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).mapToInt(MClass::getFieldCount).sum();
         return this.clazz.getDeclaredFields().length;
     }
 
@@ -219,8 +219,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public @NotNull Stream<Field> getRawFields(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(MClass::getRawFields);
-        return Arrays.stream(this.clazz.getDeclaredFields());
+        return Arrays.stream(includeSuperclasses.include() ? this.clazz.getFields() : this.clazz.getDeclaredFields());
     }
 
     @Override
@@ -230,7 +229,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public @NotNull Stream<MMethod<?>> getMethods(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(MClass::getMethods);
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).flatMap(MClass::getMethods);
         return this.getRawMethods().map(BasicMirrorMethod::from);
     }
 
@@ -242,7 +241,7 @@ public final class BasicMirrorClass<T>
     @Override
     @SuppressWarnings("unchecked")
     public @NotNull <F> Stream<MMethod<F>> getMethods(@NotNull Predicate<MMethod<F>> filter, @NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(clazz -> clazz.getMethods(filter));
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).flatMap(clazz -> clazz.getMethods(filter));
         return this.getMethods().map(method -> (MMethod<F>) method).filter(filter);
     }
 
@@ -264,7 +263,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public boolean hasMethods(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().anyMatch(MClass::hasMethods);
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).anyMatch(MClass::hasMethods);
         return this.getMethodCount() > 0;
     }
 
@@ -275,7 +274,7 @@ public final class BasicMirrorClass<T>
 
     @Override
     public int getMethodCount(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().mapToInt(MClass::getMethodCount).sum();
+        if (includeSuperclasses.include()) return this.getSuperclasses(IncludeSelf.Yes).mapToInt(MClass::getMethodCount).sum();
         return this.clazz.getDeclaredMethods().length;
     }
 
@@ -286,8 +285,11 @@ public final class BasicMirrorClass<T>
 
     @Override
     public @NotNull Stream<Method> getRawMethods(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(MClass::getRawMethods);
-        return Arrays.stream(this.clazz.getDeclaredMethods());
+        return Arrays.stream(
+            includeSuperclasses.include()
+                ? this.clazz.getMethods()
+                : this.clazz.getDeclaredMethods()
+        );
     }
 
     @Override

--- a/api/src/main/java/fade/mirror/internal/impl/BasicMirrorClass.java
+++ b/api/src/main/java/fade/mirror/internal/impl/BasicMirrorClass.java
@@ -219,7 +219,8 @@ public final class BasicMirrorClass<T>
 
     @Override
     public @NotNull Stream<Field> getRawFields(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        return Arrays.stream(includeSuperclasses.include() ? this.clazz.getFields() : this.clazz.getDeclaredFields());
+        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(MClass::getRawFields);
+        return Arrays.stream(this.clazz.getDeclaredFields());
     }
 
     @Override
@@ -285,11 +286,8 @@ public final class BasicMirrorClass<T>
 
     @Override
     public @NotNull Stream<Method> getRawMethods(@NotNull MClass.IncludeSuperclasses includeSuperclasses) {
-        return Arrays.stream(
-            includeSuperclasses.include()
-                ? this.clazz.getMethods()
-                : this.clazz.getDeclaredMethods()
-        );
+        if (includeSuperclasses.include()) return this.getSuperclasses().flatMap(MClass::getRawMethods);
+        return Arrays.stream(this.clazz.getDeclaredMethods());
     }
 
     @Override

--- a/api/src/test/java/fade/mirror/MockUserTest.java
+++ b/api/src/test/java/fade/mirror/MockUserTest.java
@@ -2,6 +2,7 @@ package fade.mirror;
 
 import fade.mirror.filter.Filter;
 import fade.mirror.mock.MockUser;
+import fade.mirror.mock.MockUserSubClass;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -61,5 +62,18 @@ class MockUserTest {
         Optional<String> value = field.getValue(user);
         assertTrue(value.isPresent(), "'value' is absent");
         assertEquals("bob", value.get(), "'username' did not match");
+    }
+
+    @Test
+    @DisplayName("access inherited fields")
+    void testInheritedFields() {
+        Optional<MField<String>> roleField = mirror(MockUserSubClass.class)
+            .getField(Filter.forFields().withName("role").ofType(String.class), MClass.IncludeSuperclasses.Yes);
+
+        Optional<MField<String>> usernameField = mirror(MockUserSubClass.class)
+            .getField(Filter.forFields().withName("username").ofType(String.class), MClass.IncludeSuperclasses.Yes);
+
+        assertTrue(roleField.isPresent(), "'roleField' is absent"); // test own field
+        assertTrue(usernameField.isPresent(), "'usernameField' is absent"); // test inherited field
     }
 }

--- a/api/src/test/java/fade/mirror/mock/MockUserSubClass.java
+++ b/api/src/test/java/fade/mirror/mock/MockUserSubClass.java
@@ -1,0 +1,23 @@
+package fade.mirror.mock;
+
+public class MockUserSubClass extends MockUser {
+	private final String role;
+	private int score;
+
+	public MockUserSubClass(String username, String email, String role) {
+		super(username, email);
+		this.role = role;
+	}
+
+	public String getRole() {
+		return this.role;
+	}
+
+	public int getScore() {
+		return this.score;
+	}
+
+	public void setScore(int score) {
+		this.score = score;
+	}
+}


### PR DESCRIPTION
This pr fixes a bug in which `getFields` and `getMethods` fail to return fields and methods defined on the current class when `IncludeSuperclasses` is set to yes.